### PR TITLE
Update Tooltip.js

### DIFF
--- a/src/components/tooltip/Tooltip.js
+++ b/src/components/tooltip/Tooltip.js
@@ -313,7 +313,7 @@ const Tooltip = {
         else {
             el.$_ptooltipValue = options.value.value;
             el.$_ptooltipDisabled = options.value.disabled;
-            el.$_ptooltipEscape = false;
+            el.$_ptooltipEscape = options.value.escape;
         }
     }
 };


### PR DESCRIPTION
If an object is passed in which a string with HTML tags is passed, with the "escape" option specified, no "innerHTML" occurs. Added a fix that solves this problem, please roll it out to "npm". Thank you!

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.